### PR TITLE
ignore EOF decoding error when decoding image database

### DIFF
--- a/db.go
+++ b/db.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"sync"
 )
@@ -232,5 +233,8 @@ func newImageDB(dbpath string) (*imageDB, error) {
 		Aliases: make(map[string]string),
 	}
 	err = json.NewDecoder(f).Decode(&db)
-	return db, err
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	return db, nil
 }


### PR DESCRIPTION
In the case of newImageDB being called on an empty image database, `newImageDB` would fail with `EOF`. This PR changes `newImageDB` so that in the event of an `EOF` decoding error, an empty imageDB is returned.